### PR TITLE
Fix USB vendor ID for NuPrime DAC-10

### DIFF
--- a/SRPMS/patches/kernel/0001-Add-native-DSD-support-for-the-NuPrime-DAC-10.patch
+++ b/SRPMS/patches/kernel/0001-Add-native-DSD-support-for-the-NuPrime-DAC-10.patch
@@ -16,7 +16,7 @@ index 7af23f3..b66c56f 100644
  			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
  		break;
  
-+	case USB_ID(0x16b0, 0x06b2): /* NuPrime DAC-10 */
++	case USB_ID(0x16d0, 0x06b2): /* NuPrime DAC-10 */
  	case USB_ID(0x20b1, 0x000a): /* Gustard DAC-X20U */
  	case USB_ID(0x20b1, 0x2009): /* DIYINHK DSD DXD 384kHz USB to I2S/DSD */
  	case USB_ID(0x20b1, 0x2023): /* JLsounds I2SoverUSB */


### PR DESCRIPTION
USB Vendor ID was inconsistent with other NuPrime DACs. Confirmed DAC-10 VID is identical to other NuPrime hardware with /proc/sound/card trace. 

[NuPrime DAC 9](
https://github.com/lintweaker/xmos-native-dsd/commit/a444a9e0e7b0236b6c914250787f6aa7f5fbea23)
`case USB_ID(0x16d0, 0x09db): /* NuPrime Audio DAC-9 */`

[NuPrime IDA-8](https://github.com/lintweaker/xmos-native-dsd/blob/37b6fc4669e6559defd484c239c0feb420951c7e/SRPMS/patches/kernel/0001-usb-Add-native-DSD-support-for-NuPrime-IDA-8.patch)
`case USB_ID(0x16d0, 0x09d8): /* NuPrime IDA-8 */`